### PR TITLE
Use bundler 1.17.3

### DIFF
--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -62,7 +62,7 @@ ENV BUNDLE_SILENCE_ROOT_WARNING 1
 RUN echo 'gem: --no-rdoc --no-ri --no-document' > /root/.gemrc \
   && ssh-keyscan -H github.com >> /etc/ssh/ssh_known_hosts \
   && gem update --system 2.6.1 \
-  && gem install bundler --version 1.15.1 \
+  && gem install bundler --version 1.17.3 \
   && bundle config --global jobs 7 \
   && bundle config git.allow_insecure true \
   && bundle config --global build.nokogiri --use-system-libraries

--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -61,8 +61,10 @@ ENV BUNDLE_SILENCE_ROOT_WARNING 1
 # https://github.com/bundler/bundler/issues/4402
 RUN echo 'gem: --no-rdoc --no-ri --no-document' > /root/.gemrc \
   && ssh-keyscan -H github.com >> /etc/ssh/ssh_known_hosts \
-  && gem update --system 2.6.1 \
-  && gem install bundler --version 1.15.1 \
+  && gem update --system \
+  && gem install bundler \
+  && gem install executable-hooks -v ">=1.3.2" \
+  && gem regenerate_binstubs \
   && bundle config --global jobs 7 \
   && bundle config git.allow_insecure true \
   && bundle config --global build.nokogiri --use-system-libraries


### PR DESCRIPTION
Уже надоели предупреждения:

```
Warning: the running version of Bundler (1.15.1) is older than the version that created
the lockfile (1.17.3).
```

Плюс довольно часто возникают ошибки типа

```
Retrying fetcher due to error (2/4): Bundler::HTTPError Could not fetch specs from https://rubygems.org/
Retrying fetcher due to error (3/4): Bundler::HTTPError Could not fetch specs from https://rubygems.org/
Retrying fetcher due to error (4/4): Bundler::HTTPError Could not fetch specs from https://rubygems.org/
Could not fetch specs from https://rubygems.org/
```
И валится `dip bundle install`. Иногда сборка бандла в гемах затягивается на пол часа из-за какой-то непонятной причины. Может быть с новой версией будет лучше.