### PR TITLE
fix: fix git dubious ownership for localgems

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -86,5 +86,5 @@ UserKnownHostsFile=/dev/null\n'\
 
 ENTRYPOINT ["/tini", "--"]
 
-RUN git config --global --add safe.directory /app
+RUN git config --global --add safe.directory "*"
 WORKDIR /app


### PR DESCRIPTION
Уберет варнинг гита при подключении локальных гемов
`fatal: detected dubious ownership in repository at '/localgems/<gem_name>'`